### PR TITLE
Remove scraperwiki.json

### DIFF
--- a/app/static/scraperwiki.json
+++ b/app/static/scraperwiki.json
@@ -1,6 +1,0 @@
-{
-  "displayName": "View in a table",
-  "description": "Sort, search and page through your data",
-  "icon": "https://s3-eu-west-1.amazonaws.com/sw-icons/tool-icon-data-table.png",
-  "color": "#f6b730"
-}


### PR DESCRIPTION
Was used on ScraperWiki; not needed for standalone running.
